### PR TITLE
Add slave server synchronization and test for MXS-716

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ add_test_script(mxs791_galera.sh galera)
 add_test_executable(mxs799_crash_bad_socket.cpp mxs799_crash_bad_socket mxs799)
 add_test_executable(user_cache.cpp user_cache user_cache)
 add_test_executable(mxs813_long_hostname.cpp mxs813_long_hostname setup_binlog)
+add_test_executable(mxs716.cpp mxs716 replication)
 
 # Python based tests
 add_test_script(mxs585.py replication)
@@ -433,6 +434,7 @@ light_weight_tests(
   server_weight
   setup_binlog_crc_none
   test_hints
+  mxs716
   )
 
 # See if we are on a RPM-capable or DEB-capable system

--- a/mariadb_func.cpp
+++ b/mariadb_func.cpp
@@ -45,7 +45,7 @@ int set_ssl(MYSQL * conn)
  * @param ssl   true if ssl should be used
  * @return MYSQL struct or NULL in case of error
  */
-MYSQL * open_conn_db_flags(int port, char * ip, char * db, char * User, char * Password, unsigned long flag, bool ssl)
+MYSQL * open_conn_db_flags(int port, const char* ip, const char* db, const char* User, const char* Password, unsigned long flag, bool ssl)
 {
     MYSQL * conn = mysql_init(NULL);
 
@@ -86,7 +86,7 @@ MYSQL * open_conn_db_flags(int port, char * ip, char * db, char * User, char * P
  * @param ssl   true if ssl should be used
  * @return MYSQL struct or NULL in case of error
  */
-MYSQL * open_conn_db_timeout(int port, char * ip, char * db, char * User, char * Password, unsigned long timeout, bool ssl)
+MYSQL * open_conn_db_timeout(int port, const char* ip, const char* db, const char* User, const char* Password, unsigned long timeout, bool ssl)
 {
     MYSQL * conn = mysql_init(NULL);
 
@@ -133,7 +133,7 @@ MYSQL * open_conn_db_timeout(int port, char * ip, char * db, char * User, char *
  * @param ssl   true if ssl should be used
  * @return MYSQL struct or NULL in case of error
  */
-MYSQL * open_conn_db(int port, char * ip, char * db, char * User, char * Password, bool ssl)
+MYSQL * open_conn_db(int port, const char* ip, const char* db, const char* User, const char* Password, bool ssl)
 {
     return(open_conn_db_flags(port, ip, db, User, Password, CLIENT_MULTI_STATEMENTS, ssl));
 }
@@ -148,9 +148,9 @@ MYSQL * open_conn_db(int port, char * ip, char * db, char * User, char * Passwor
  * @param ssl   true if ssl should be used
  * @return MYSQL struct or NULL in case of error
  */
-MYSQL * open_conn(int port, char * ip, char * User, char * Password, bool ssl)
+MYSQL * open_conn(int port, const char* ip, const char* User, const char* Password, bool ssl)
 {
-    return(open_conn_db(port, ip, (char *) "test", User, Password, ssl));
+    return(open_conn_db(port, ip, "test", User, Password, ssl));
 }
 
 /**
@@ -163,7 +163,7 @@ MYSQL * open_conn(int port, char * ip, char * User, char * Password, bool ssl)
  * @param ssl   true if ssl should be used
  * @return MYSQL struct or NULL in case of error
  */
-MYSQL * open_conn_no_db(int port, char * ip, char *User, char *Password, bool ssl)
+MYSQL * open_conn_no_db(int port, const char* ip, const char*User, const char*Password, bool ssl)
 {
     return(open_conn_db_flags(port, ip, NULL, User, Password, CLIENT_MULTI_STATEMENTS, ssl));
 }

--- a/mariadb_func.h
+++ b/mariadb_func.h
@@ -26,11 +26,11 @@
 #include <math.h>
 #include <time.h>
 
-MYSQL * open_conn_db_flags(int port, char * ip, char * db, char * User, char * Password, unsigned long flag, bool ssl);
-MYSQL * open_conn_db_timeout(int port, char * ip, char * db, char * User, char * Password, unsigned long timeout, bool ssl);
-MYSQL * open_conn_db(int port, char * ip, char * db, char * User, char * Password, bool ssl);
-MYSQL * open_conn(int port, char * ip, char *User, char *Password, bool ssl);
-MYSQL * open_conn_no_db(int port, char * ip, char *User, char *Password, bool ssl);
+MYSQL * open_conn_db_flags(int port, const char* ip, const char* db, const char* User, const char* Password, unsigned long flag, bool ssl);
+MYSQL * open_conn_db_timeout(int port, const char* ip, const char* db, const char* User, const char* Password, unsigned long timeout, bool ssl);
+MYSQL * open_conn_db(int port, const char* ip, const char* db, const char* User, const char* Password, bool ssl);
+MYSQL * open_conn(int port, const char* ip, const char* User, const char* Password, bool ssl);
+MYSQL * open_conn_no_db(int port, const char* ip, const char* User, const char* Password, bool ssl);
 int set_ssl(MYSQL * conn);
 int execute_query(MYSQL *conn, const char *sql);
 int execute_query_silent(MYSQL *conn, const char *sql);

--- a/mariadb_nodes.h
+++ b/mariadb_nodes.h
@@ -409,6 +409,14 @@ public:
      * @return exit code of the system command or 1 in case of i > N
      */
     int copy_to_node(char* src, char* dest, int i);
+
+    /**
+     * @brief Synchronize slaves with the master
+     *
+     * Only works with master-slave replication and should not be used with Galera clusters.
+     * The function expects that the first node, @c nodes[0], is the master.
+     */
+    void sync_slaves();
 };
 
 #endif // MARIADB_NODES_H

--- a/mxs716.cpp
+++ b/mxs716.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file mxs716.cpp Test for MXS-716
+ *
+ * Connect using different default databases with database and table level grants.
+ */
+
+
+#include <my_config.h>
+#include <iostream>
+#include <unistd.h>
+#include "testconnections.h"
+#include "sql_t1.h"
+
+void run_test(TestConnections* Test, const char* database)
+{
+
+    Test->set_timeout(20);
+    Test->tprintf("Trying to connect using 'table_privilege'@'%' to database 'test'");
+
+    MYSQL* conn = open_conn_db(Test->rwsplit_port, Test->maxscale_IP, "test", "table_privilege", "pass", Test->ssl);
+
+    if (conn && mysql_errno(conn) == 0)
+    {
+        Test->set_timeout(20);
+        Test->tprintf("Trying SELECT on %s.t1", database);
+        Test->try_query(conn, "SELECT * FROM t1");
+    }
+    else
+    {
+        Test->add_result(1, "Failed to connect using database '%s': %s", database, mysql_error(conn));   
+    }
+
+    mysql_close(conn);
+}
+
+int main(int argc, char *argv[])
+{
+    TestConnections* Test = new TestConnections(argc, argv);
+
+    Test->connect_maxscale();
+    Test->tprintf("Preparing test");
+    Test->set_timeout(120);
+    execute_query(Test->conn_rwsplit, "CREATE USER 'table_privilege'@'%' IDENTIFIED BY 'pass'");
+    execute_query(Test->conn_rwsplit, "CREATE DATABASE db1");
+    execute_query(Test->conn_rwsplit, "CREATE DATABASE db2");
+    execute_query(Test->conn_rwsplit, "CREATE DATABASE db3");
+    execute_query(Test->conn_rwsplit, "CREATE DATABASE db4");
+    execute_query(Test->conn_rwsplit, "CREATE TABLE db1.t1 (id INT)");
+    execute_query(Test->conn_rwsplit, "CREATE TABLE db2.t1 (id INT)");
+    execute_query(Test->conn_rwsplit, "CREATE TABLE db3.t1 (id INT)");
+    execute_query(Test->conn_rwsplit, "CREATE TABLE db4.t1 (id INT)");
+    execute_query(Test->conn_rwsplit, "GRANT SELECT ON db1.* TO 'table_privilege'@'%'");
+    execute_query(Test->conn_rwsplit, "GRANT SELECT ON db2.* TO 'table_privilege'@'%'");
+    execute_query(Test->conn_rwsplit, "GRANT SELECT ON db3.t1 TO 'table_privilege'@'%'");
+    execute_query(Test->conn_rwsplit, "GRANT SELECT ON db4.t1 TO 'table_privilege'@'%'");
+    Test->repl->sync_slaves();
+
+    run_test(Test, "db1");
+    run_test(Test, "db2");
+    run_test(Test, "db3");
+    run_test(Test, "db4");
+    Test->check_maxscale_alive();
+
+    Test->tprintf("Cleaning up...");
+    Test->set_timeout(60);
+    Test->try_query(Test->conn_rwsplit, "DROP USER 'table_privilege'@'%'");
+    Test->try_query(Test->conn_rwsplit, "DROP DATABASE db1");
+    Test->try_query(Test->conn_rwsplit, "DROP DATABASE db2");
+    Test->try_query(Test->conn_rwsplit, "DROP DATABASE db3");
+    Test->try_query(Test->conn_rwsplit, "DROP DATABASE db4");
+
+    Test->copy_all_logs();
+    return Test->global_result;
+}
+

--- a/testconnections.cpp
+++ b/testconnections.cpp
@@ -235,6 +235,11 @@ void TestConnections::add_result(int result, const char *format, ...)
         va_start(argp, format);
         vprintf(format, argp);
         va_end(argp);
+
+        if (format[strlen(format) - 1] != '\n')
+        {
+            printf("\n");
+        }
     }
 }
 
@@ -1122,6 +1127,12 @@ int TestConnections::tprintf(const char *format, ...)
     va_start(argp, format);
     vprintf(format, argp);
     va_end(argp);
+
+    /** Add a newline if the message doesn't have one */
+    if (format[strlen(format) - 1] != '\n')
+    {
+        printf("\n");
+    }
 }
 
 void *timeout_thread( void *ptr )


### PR DESCRIPTION
Slave servers can now be synchronized with Mariadb_nodes::sync_slaves().
It makes sure that slaves are up-to-date before returning from the function.

New test for MXS-716 is similar to mxs37_table_privilege but expands the checks.